### PR TITLE
Fix 3 issues

### DIFF
--- a/app/src/main/java/com/mtesitoo/HomeActivity.java
+++ b/app/src/main/java/com/mtesitoo/HomeActivity.java
@@ -100,22 +100,22 @@ public class HomeActivity extends AppCompatActivity {
                         new SecondaryDrawerItem()
                                 .withName(R.string.drawer_item_home)
                                 .withIcon(GoogleMaterial.Icon.gmd_home)
-                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_home_index)))
-                                .withSelectable(false),
+                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_home_index))),
                         new SectionDrawerItem()
                                 .withName(R.string.drawer_item_section_header_account),
                         new SecondaryDrawerItem()
                                 .withName(R.string.drawer_item_profile)
                                 .withIcon(GoogleMaterial.Icon.gmd_face)
-                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_profile_index)))
-                                .withSelectable(false),
+                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_profile_index))),
                         new SecondaryDrawerItem()
                                 .withName(R.string.drawer_item_orders)
                                 .withIcon(GoogleMaterial.Icon.gmd_history)
-                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_order_index)))
-                                .withBadgeStyle(new BadgeStyle()
+                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_order_index))),
+                                // Todo orders menu - displays number of pending orders.
+                                // Uncomment the lines below to display the number of orders next to the menu item
+                                /*.withBadgeStyle(new BadgeStyle()
                                         .withTextColor(Color.WHITE)
-                                        .withColorRes(R.color.md_red_700)),
+                                        .withColorRes(R.color.md_red_700)),*/
                         new SecondaryDrawerItem()
                                 .withName(R.string.drawer_item_new)
                                 .withIcon(GoogleMaterial.Icon.gmd_add)
@@ -125,13 +125,11 @@ public class HomeActivity extends AppCompatActivity {
                         new SecondaryDrawerItem()
                                 .withName(R.string.drawer_item_info)
                                 .withIcon(GoogleMaterial.Icon.gmd_info_outline)
-                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_info_index)))
-                                .withSelectable(false),
+                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_info_index))),
                         new SecondaryDrawerItem()
                                 .withName(R.string.drawer_item_help)
                                 .withIcon(GoogleMaterial.Icon.gmd_help_outline)
-                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_help_index)))
-                                .withSelectable(false),
+                                .withIdentifier(Integer.parseInt(mContext.getString(R.string.menu_item_help_index))),
                         new SecondaryDrawerItem()
                                 .withName(R.string.drawer_item_exit)
                                 .withIcon(GoogleMaterial.Icon.gmd_exit_to_app)
@@ -161,7 +159,7 @@ public class HomeActivity extends AppCompatActivity {
                             }
 
                             if (f != null) {
-                                getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, f).commit();
+                                getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, f).addToBackStack(null).commit();
                             }
                         }
 
@@ -171,6 +169,9 @@ public class HomeActivity extends AppCompatActivity {
                 .withShowDrawerOnFirstLaunch(true)
                 .build();
 
-        result.updateBadge(3, new StringHolder(10 + ""));
+        // Todo orders menu - displays number of pending orders.
+        // functionality not yet implemented.
+        // Badge has been commented out above.
+        // result.updateBadge(3, new StringHolder(10 + ""));
     }
 }


### PR DESCRIPTION
Hide badge next to orders that display the number of pending orders
Back button navigation for fragments in HomeActivity
Drawer menu items not being highlighted properly