### PR TITLE
Remove Add button from Orders, Profile, Info, Help screens

### DIFF
--- a/app/src/main/java/com/mtesitoo/HomeActivity.java
+++ b/app/src/main/java/com/mtesitoo/HomeActivity.java
@@ -7,8 +7,6 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
@@ -56,25 +54,6 @@ public class HomeActivity extends AppCompatActivity {
 
         ProductFragment f = ProductFragment.newInstance(this, mSeller);
         getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, f).commit();
-    }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.menu_home, menu);
-        return true;
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
-
-        if (id == R.id.action_add_product) {
-            Intent intent = new Intent(this, AddProductActivity.class);
-            startActivity(intent);
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
     }
 
     public void buildNavigationDrawer() {

--- a/app/src/main/java/com/mtesitoo/adapter/OrderProductListAdapter.java
+++ b/app/src/main/java/com/mtesitoo/adapter/OrderProductListAdapter.java
@@ -105,7 +105,7 @@ public class OrderProductListAdapter extends ArrayAdapter<OrderProduct>
         public void onClick(View view) {
             Fragment f = EditOrderFragment.newInstance(context, orderProduct, order);
             FragmentActivity fragmentActivity = (FragmentActivity)context;
-            fragmentActivity.getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, f).commit();
+            fragmentActivity.getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, f).addToBackStack(null).commit();
         }
 
 

--- a/app/src/main/java/com/mtesitoo/fragment/OrderFragment.java
+++ b/app/src/main/java/com/mtesitoo/fragment/OrderFragment.java
@@ -122,7 +122,7 @@ public class OrderFragment extends ListFragment {
     }
 
     @Override
-    public void onDestroy() {
+    public void onPause() {
         super.onDestroy();
         //restore the title of the app to the default.
         getActivity().setTitle(R.string.app_name);

--- a/app/src/main/java/com/mtesitoo/fragment/ProductFragment.java
+++ b/app/src/main/java/com/mtesitoo/fragment/ProductFragment.java
@@ -1,12 +1,17 @@
 package com.mtesitoo.fragment;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.mtesitoo.AddProductActivity;
 import com.mtesitoo.R;
 import com.mtesitoo.adapter.ProductListAdapter;
 import com.mtesitoo.backend.model.Product;
@@ -19,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Created by Nan on 12/30/2015.
+ * Created by Nan on 12/30/2015
  */
 public class ProductFragment extends ListFragment {
     private ProductListAdapter mProductListAdapter;
@@ -31,6 +36,34 @@ public class ProductFragment extends ListFragment {
         args.putParcelable(context.getString(R.string.bundle_seller_key), seller);
         fragment.setArguments(args);
         return fragment;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_home, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        switch(item.getItemId())
+        {
+            case R.id.action_add_product:
+                Intent intent = new Intent(getContext(), AddProductActivity.class);
+                startActivity(intent);
+                return true;
+
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState )
+    {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
     }
 
     @Override


### PR DESCRIPTION
The Add Product button should only be shown on the ProductFragment rather than the main activity.