### PR TITLE
Correct use of API, so that all the vendor's products are shown

### DIFF
--- a/libs/mtesitoo-backend-api/src/main/java/com/mtesitoo/backend/model/url/VendorProductsURL.java
+++ b/libs/mtesitoo-backend-api/src/main/java/com/mtesitoo/backend/model/url/VendorProductsURL.java
@@ -8,9 +8,7 @@ import com.mtesitoo.backend.model.URL;
  * Created by Nan on 9/19/2015.
  */
 public class VendorProductsURL extends URL {
-    public VendorProductsURL(Context context, int resId, int sellerId) {
+    public VendorProductsURL(Context context, int resId) {
         super(context, resId);
-        mPath.append("/" + Integer.toString(sellerId));
-        mPath.append("/products");
     }
 }

--- a/libs/mtesitoo-backend-api/src/main/java/com/mtesitoo/backend/service/ProductRequest.java
+++ b/libs/mtesitoo-backend-api/src/main/java/com/mtesitoo/backend/service/ProductRequest.java
@@ -40,7 +40,7 @@ public class ProductRequest extends Request implements IProductRequest {
     @Override
     public void getProducts(final int sellerId, final ICallback<List<Product>> callback) {
         Log.d("getProducts - SellerId",String.valueOf(sellerId));
-        URL url = new VendorProductsURL(mContext, R.string.path_product_vendor, sellerId);
+        URL url = new VendorProductsURL(mContext, R.string.path_vendor_products);
         Log.d("Vendor Products URL",url.toString());
         ProductResponse response = new ProductResponse(callback);
         AuthorizedStringRequest stringRequest = new AuthorizedStringRequest(mContext, com.android.volley.Request.Method.GET, url.toString(), response, response);

--- a/libs/mtesitoo-backend-api/src/main/res/values/strings_api_resources.xml
+++ b/libs/mtesitoo-backend-api/src/main/res/values/strings_api_resources.xml
@@ -40,6 +40,8 @@
 
     <string name="path_vendor_profile_image">/vendor/profile_image</string>
 
+    <string name="path_vendor_products">/vendor/products</string>
+
     <string name="path_admin_password">/admin/password</string>
     <string name="path_admin_forgot_password">/admin/forgot_password</string>
 


### PR DESCRIPTION
Get list of products belonging to the vendor with `GET /vendor/products` instead of `GET /product/vendor/{id}/products`.

This will mean all products are shown, including expired and pending-approval ones.